### PR TITLE
Fixing Encoding

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends PluginBase
         });
 
         Route::get('_resize/file/{path}/{width}/{height}/{options?}', function($path, $width, $height, $options=[]) {
-            $path = base64_decode($path);
+            $path = urldecode($path);
             if ($options) {
                 $options = unserialize(base64_decode($options));
             }

--- a/classes/ResizeService.php
+++ b/classes/ResizeService.php
@@ -272,7 +272,7 @@ class ResizeService
             $this->queue($priority, ['type'=>'file', 'path'=>$fromPath, 'width'=>$width, 'height'=>$height, 'options'=>$options]);
         }
 
-        return URL::to('/_resize/file', [base64_encode($fromPath), $width, $height, base64_encode(serialize($options))]);
+        return URL::to('/_resize/file', [urlencode($fromPath), $width, $height, base64_encode(serialize($options))]);
     }
 
     /**


### PR DESCRIPTION
To solve the problem of non-Latin characters.
The problem is that the URL of non-Latin file names are not interpreted by route. This is an example file name:
LyDYudio2K8g2KfZhNmC2K%2FZiNizLmpwZw%3D%3D/